### PR TITLE
Fix: Replaced anchor tags with React Router <Link /> for proper routing

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import recipes from '../pages/recipes'
 import "../navbar.css"
 
@@ -40,7 +40,7 @@ const Navbar = ({ isLoggedIn, setIsLoggedIn }) => {
   return (
     <div>
       <nav className="navbar navbar-expand-lg navbar-custom">
-        <a className="navbar-brand" href="/Home">FoodIO</a>
+        <Link className="navbar-brand" to="/Home">FoodIO</Link>
         <button className="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
           <span className="navbar-toggler-icon"></span>
         </button>
@@ -48,7 +48,7 @@ const Navbar = ({ isLoggedIn, setIsLoggedIn }) => {
         <div className="collapse navbar-collapse" id="navbarSupportedContent">
           <ul className="navbar-nav mr-auto">
             <li className="nav-item active">
-              <a className="nav-link" href="/Home">Home</a>
+              <Link className="nav-link" to="/Home">Home</Link>
             </li>
 
             <div className="dropdown">
@@ -56,17 +56,17 @@ const Navbar = ({ isLoggedIn, setIsLoggedIn }) => {
                 Dashboard
               </button>
               <ul className="dropdown-menu">
-                <li><a className="dropdown-item" href="/Categories">Categories</a></li>
-                <li><a className="dropdown-item" href="/AddRecipe">Add New Recipe</a></li>
+                <li><Link className="dropdown-item" to="/Categories">Categories</Link></li>
+                <li><Link className="dropdown-item" to="/AddRecipe">Add New Recipe</Link></li>
               </ul>
             </div>
 
             <li className="nav-item">
-              <a className="nav-link" href="/About">About</a>
+              <Link className="nav-link" to="/About">About</Link>
             </li>
           </ul>
         {/* add chat button */}
-              <a className='ChatButton' href='/ai-chat'>Chat with AI</a>
+              <Link className='ChatButton' to='/ai-chat'>Chat with AI</Link>
 
           <form className="form-inline d-flex align-items-center position-relative">
             <input 
@@ -102,11 +102,11 @@ const Navbar = ({ isLoggedIn, setIsLoggedIn }) => {
               </button>
             ) : (
               <>
-                <a className="loginlink" href="/login">Login </a>
-                <a className="reglink" href="/register"> Register</a>
+                <Link className="loginlink" to="/login">Login </Link>
+                <Link className="reglink" to="/register"> Register</Link>
               </>
             )}
-            <a className="myprofile" href="/profile"><i className="fas fa-user"></i></a>
+            <Link className="myprofile" to="/profile"><i className="fas fa-user"></i></Link>
           </div>
 
           

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -110,7 +110,7 @@ const Home = () => {
                         <div className="card-body">
                             <h5 className="card-title">{recipe.title}</h5>
                             <p className="card-text">Rating: {recipe.rating}</p>
-                            <a href={`/ViewRecipe?id=${recipe.id}`} className="btn btn-primary">View Recipe</a>
+                            <Link to={`/ViewRecipe?id=${recipe.id}`} className="btn btn-primary">View Recipe</Link>
                         </div>
                     </div>
                 </div>

--- a/frontend/src/pages/profile.jsx
+++ b/frontend/src/pages/profile.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import "../profile.css";
 
 const Profile = () => {
@@ -52,7 +52,7 @@ const Profile = () => {
               <div className="recipe-actions">
                 {title === "My Recipes" && (
                   <>
-                    <a className="edit-btn" href="/AddRecipe">Edit</a>
+                    <Link className="edit-btn" to="/AddRecipe">Edit</Link>
                     <button className="delete-btn" onClick={() => handleDelete(recipe.id, title)}>Delete</button>
                   </>
                 )}


### PR DESCRIPTION
This PR fixes incorrect use of <a> tags for internal navigation in a React app by replacing them with React Router's <Link /> component.

Also, just noting that my previous PR #30 (implementing Firebase JWT auth + MongoDB Atlas) was reverted with no explanation. I even followed up asking what needed to be fixed, but got no response. If there’s something wrong, I’m happy to correct it — but silence doesn’t help contributors.

Anyway, this current fix is straightforward but important. Using <a> tags in React apps for routing breaks SPA behavior and causes full reloads — definitely not ideal.

Let me know if anything else needs to be adjusted.