### PR TITLE
Refactor auth flow to set cookie only on login and redirect new users to login page

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -2,6 +2,15 @@ import jwt from "jsonwebtoken";
 import bcrypt from "bcrypt";
 import { UserModel } from "../models/Users.js";
 
+// Helper to set cookie
+const setAuthCookie = (res, token) => {
+  res.cookie("token", token, {
+    httpOnly: true,
+    secure: process.env.PRODUCTION === "true",
+    sameSite: "strict",
+  });
+};
+
 // Register Controller
 const register = async (req, res) => {
   try {
@@ -22,19 +31,8 @@ const register = async (req, res) => {
 
     await newUser.save();
 
-    const token = jwt.sign(
-      { id: newUser._id },
-      process.env.JWT_SECRET || "secret",
-      { expiresIn: "7d" }
-    );
-
-    res.cookie("token", token, {
-      httpOnly: true,
-      secure: process.env.PRODUCTION === "true", 
-      sameSite: "strict",
-    });
-
-    res.status(201).json({ message: "User registered successfully" });
+    // No cookie set here — user will log in after registering
+    res.status(201).json({ message: "User registered successfully. Please log in." });
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: "Internal server error" });
@@ -62,11 +60,7 @@ const login = async (req, res) => {
       { expiresIn: "7d" }
     );
 
-    res.cookie("token", token, {
-      httpOnly: true,
-      secure: process.env.PRODUCTION === "true",
-      sameSite: "strict",
-    });
+    setAuthCookie(res, token);
 
     res.status(200).json({ message: "Logged in successfully" });
   } catch (err) {
@@ -75,10 +69,11 @@ const login = async (req, res) => {
   }
 };
 
+// Logout Controller
 const logout = async (req, res) => {
   try {
     res.clearCookie("token", {
-   httpOnly: true,
+      httpOnly: true,
       secure: process.env.PRODUCTION === "true",
       sameSite: "strict",
     });
@@ -89,4 +84,5 @@ const logout = async (req, res) => {
     res.status(500).json({ message: "Internal server error" });
   }
 };
-export { register, login,logout };
+
+export { register, login, logout };

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -20,7 +20,7 @@ const Register = ({ setIsLoggedIn }) => {
           localStorage.setItem("loggedIn", true);
         setIsLoggedIn(true);
     alert("Registration successful!");
-    navigate("/");
+    navigate("/login");
   };
 
   return (


### PR DESCRIPTION
Removed redundant cookie-setting logic from the register controller to ensure cookies are only set upon successful login. Added a helper function setAuthCookie to centralize cookie creation in the login flow. Updated registration response to instruct clients to redirect users to the login page after account creation, improving clarity and maintainability.

fixes #115 


https://github.com/user-attachments/assets/d1df014e-3ee9-4514-a7ae-bce6f60bb481

