### PR TITLE
[Bug] Inconsistency In dark mode across pages and footer dynamic date - Fixed

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -80,9 +80,11 @@ useEffect(() => {
     <Router>
       <ScrollToTop />
 
-      <Navbar isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} isHomeScreen={isHomeScreen}  recipes={recipes}/>
-
-      <Navbar isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />
+      <Navbar 
+        isLoggedIn={isLoggedIn} 
+        setIsLoggedIn={setIsLoggedIn} 
+        recipes={recipes}
+      />
 
       <Routes>
         <Route path="/" element={<Home /> } />

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -93,7 +93,8 @@ function Footer() {
   }, []);
 
   return (
-    <footer className="enhanced-footer" aria-label="Site footer">
+    // Change hardcoded colors to use CSS variables
+    <footer className="enhanced-footer" style={{ backgroundColor: 'var(--bg-color)', color: 'var(--text-color)' }}>
       <div className="container-fluid px-4">
         <div className="row align-items-start g-4 justify-content-between">
           <div className="col-12 col-md-6 col-lg-3 footer-section">
@@ -234,7 +235,7 @@ function Footer() {
         </section>
 
         <div className="copyright-section">
-          <p className="copyright-text">&copy; 2024 Foodio. All rights reserved.</p>
+          <p className="copyright-text">&copy; {new Date().getFullYear()} Foodio. All rights reserved.</p>
           <div className="copyright-links">
             <Link to="/PrivacyPolicy" className="copyright-link">Privacy Policy</Link>
             <Link to="/TermsOfService" className="copyright-link">Terms of Service</Link>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,3 +11,15 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+[data-theme="dark"] {
+  --bg-color: #1a1a1a;
+  --text-color: #ffffff;
+  --primary-color: #da8f48;
+  /* Add other dark mode variables as needed */
+}
+
+[data-theme="dark"] body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}


### PR DESCRIPTION
Bug 1: The dark Mode was not being consistently applied across the website. I fixed that by editing the CSS and App.js files.

Bug 2: The footer year was hardcoded and to be dynamically changed, I used Date() function to update it automatically.

Bug 3: Changed the colour of the scroll bar to make it look better in both Light and Dark Mode.

fixing issue: #146 

Images: 
Before - 
<img width="509" height="134" alt="Screenshot 2025-08-14 at 22 20 08" src="https://github.com/user-attachments/assets/63ddb327-7493-4802-b84f-f44a6a9a106a" />
<img width="1470" height="863" alt="Screenshot 2025-08-14 at 22 20 29" src="https://github.com/user-attachments/assets/688e6b82-af59-47da-a881-e287cc2e4add" />
<img width="1463" height="865" alt="Screenshot 2025-08-14 at 22 20 49" src="https://github.com/user-attachments/assets/70d5d885-5cd2-4089-a661-5f5fc057b04c" />

After - 
<img width="1469" height="881" alt="Screenshot 2025-08-14 at 22 21 14" src="https://github.com/user-attachments/assets/99168b85-51ea-431f-ac82-c64c7d933ee6" />
<img width="1470" height="879" alt="Screenshot 2025-08-14 at 22 21 38" src="https://github.com/user-attachments/assets/da99761a-0d5a-4f71-a09a-b2f3df99cd9c" />
<img width="1470" height="881" alt="Screenshot 2025-08-14 at 22 21 49" src="https://github.com/user-attachments/assets/b3e0c95e-1205-4745-8fad-8e80f2a96f60" />

Name - Bhaanavee C S
Github username - Bhaanavee
Contributor - GSSoC